### PR TITLE
backend isHealthy debugging

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -6,8 +6,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/goccy/go-json"
-	"github.com/valyala/fasthttp"
 	"io"
 	"math"
 	"math/rand"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/valyala/fasthttp"
 
 	sw "github.com/ethereum-optimism/infra/proxyd/pkg/avg-sliding-window"
 	"github.com/ethereum/go-ethereum/common"
@@ -718,9 +719,11 @@ func (b *Backend) IsHealthy() bool {
 	errorRate := b.ErrorRate()
 	avgLatency := time.Duration(b.latencySlidingWindow.Avg())
 	if errorRate >= b.maxErrorRateThreshold {
+		log.Warn("backend errorRate above maxErrorRateThreshold", "backend", b.Name, "errorRate", errorRate, "maxErrorRateThreshold", b.maxErrorRateThreshold)
 		return false
 	}
 	if avgLatency >= b.maxLatencyThreshold {
+		log.Warn("backend avgLatency above maxLatencyThreshold", "backend", b.Name, "avgLatency", avgLatency, "maxLatencyThreshold", b.maxLatencyThreshold)
 		return false
 	}
 	return true


### PR DESCRIPTION
looking through the logs and source code, I _think_ that the reason we can't find a "healthy backend" occasionally is due to either all backends' latency or error rate too high.  add some debugging to check

## Additional context

I looking through the possible errors when no backend is healthy, there are few that could occuring during either of these `for` loops:

https://github.com/hemilabs/optimism-infra/blob/147a33afc3ffe62cc7c1025f3d201049451da3d6/proxyd/backend.go#L996

https://github.com/hemilabs/optimism-infra/blob/147a33afc3ffe62cc7c1025f3d201049451da3d6/proxyd/backend.go#L1438

I don't see any of those errors in the logs, so _I think that what is causing the issues is what creates the `backends` slice_

I have a theory they may being filtered out when checking for if they're healthy, I think that happens here

https://github.com/hemilabs/optimism-infra/blob/147a33afc3ffe62cc7c1025f3d201049451da3d6/proxyd/backend.go#L1069

I want to add some debugging to `IsHealthy` to see if that is the case